### PR TITLE
Add commit-msg hook install to README steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,7 @@
             stages: [commit-msg]
             additional_dependencies: ['@commitlint/config-angular']
     ```
-
-
+- Install the [`commit-msg`](https://pre-commit.com/#pre-commit-for-commit-messages) hook in your project repo:
+    ```shell
+    pre-commit install --hook-type commit-msg
+    ```


### PR DESCRIPTION
Hey Alessandro! Thanks for this repo!

As I was getting it set up in my project, I was missing the piece where you need
to install the `commit-msg` hook via the command line. I think adding this step
to the `README` might be helpful for folks who are new to commitlint and
pre-commit. What do you think?