### PR TITLE
Make the commitlint hook always run

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,8 @@
   description: Commitlint hook
   language: node
   entry: commitlint --edit
+  always_run: true
+  pass_filenames: false
 - id: commitlint-travis
   name: Check commit messages on Travis CI
   description: Lint all relevant commits for a change or PR on Travis CI


### PR DESCRIPTION
Hi Alessandro,

Thank you for this convenient repo.

I followed the instructions to install your `commitlint` pre-commit hook, but I struggled to get it to actually validate my commit messages. The hook would always pass with
```console
commitlint...........................................(no files to check)Skipped
```

To get the hook to always run, I needed to add `always_run: true` to the hook. I also added `pass_filenames: false` to be consistent with your `commitlint-travis` hook. Now it always validates my commit messages:
```console
[james@precept test-repo] (main)$ git commit -m 'non-conventional commit'
commitlint...............................................................Failed
- hook id: commitlint
- exit code: 1

⧗   input: non-conventional commit
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]

✖   found 2 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```

Does this change make sense, or am I misunderstanding how to use the hook?