### PR TITLE
fix: do not pass filename to commitlint hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,9 @@
   description: Commitlint hook
   language: node
   entry: commitlint --edit
+  pass_filenames: false
+  always_run: true
+  verbose: true
 - id: commitlint-travis
   name: Check commit messages on Travis CI
   description: Lint all relevant commits for a change or PR on Travis CI


### PR DESCRIPTION
Closes #66 